### PR TITLE
fix teams cards to be left-aligned

### DIFF
--- a/team.html
+++ b/team.html
@@ -43,7 +43,7 @@ title: Meet our core team
         <h1>Contributors</h1>
         <div class="row g-3">
             {% for person in site.data.collaborators %}
-            <div class="col-12 col-md-6 col-lg-3 mx-auto">
+            <div class="col-12 col-md-6 col-lg-3">
                 <div class="contributors card">
                     <img src="{{person.image}}" alt="profile photo" class="profile photo card-img-top">
                     <div class="card-body">


### PR DESCRIPTION
- Fix cards on teams page to be left-aligned

Before:
![teams-card-align-before](https://user-images.githubusercontent.com/26842896/213876325-5da4ae1c-0970-4bed-a650-f22e2a93d699.png)

After:
![teams-card-align-after](https://user-images.githubusercontent.com/26842896/213876328-cb122e8c-415b-4689-9097-e1476c8eb29e.png)


## Type Of Change
- [ ] Update documentation
- [ ] Add feature
- [x] Fix 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Commit message is as per guidelines in the [contributor guide](https://github.com/WomenWhoCode/london/blob/main/CONTRIBUTING.md)