### PR TITLE
fix code owerner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @WomenWhoCode/wwcode-london
-* @dricazenck
-* @nora-weisser
+* @WomenWhoCode/wwcode-london @dricazenck @nora-weisser


### PR DESCRIPTION
Adjust code owners to be @dricazenck, @nora-weisser and @WomenWhoCode/wwcode-london 