### PR TITLE
fix home registration columns width

### DIFF
--- a/_sass/custom/_home.scss
+++ b/_sass/custom/_home.scss
@@ -52,6 +52,12 @@
             font-weight: $font-weight-bold !important;
             font-size: larger;
         }
+
+        .mentor {
+            @include media-breakpoint-down(sm) {
+                margin-bottom: 3em;
+            }
+        }
     }
 
     .card-header {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: "Mentorship Program"
         </div>
 
         <div class="row registration">
-            <div class="col-5 mentor">
+            <div class="col-xs-12 col-md-5 mentor">
                 <p>You should apply to be a <span>mentor</span> if you:</p>
 
                 <ul>
@@ -30,7 +30,7 @@ title: "Mentorship Program"
                 </p>
             </div>
             
-            <div class="col-5 mentee">
+            <div class="col-xs-12 col-md-5 mentee">
                 <p>You should apply to be a <span>mentee</span> if you:</p>
 
                 <ul>


### PR DESCRIPTION
- Fix home mentor and mentee registrations columns' width to be full width on mobile

Before:
![colums-before](https://user-images.githubusercontent.com/26842896/214126601-5da49411-2398-4f7e-ab77-524c1ce78bf6.png)

After:
![colums-after](https://user-images.githubusercontent.com/26842896/214126622-28a2c774-a5c2-46bf-9c9b-f31029cae5ff.png)


## Type Of Change
- [ ] Update documentation
- [ ] Add feature
- [x] Fix 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Commit message is as per guidelines in the [contributor guide](https://github.com/WomenWhoCode/london/blob/main/CONTRIBUTING.md)