### PR TITLE
Fix homepage header responsiveness and center text vertically

### DIFF
--- a/_sass/custom/_home.scss
+++ b/_sass/custom/_home.scss
@@ -15,9 +15,6 @@
     background-position: center top;
 
     h1 {
-        @include media-breakpoint-down(md) {  
-            background-size: auto 100%;
-        }
         @extend .display-2;
         margin: 0 !important;
     }

--- a/_sass/custom/_home.scss
+++ b/_sass/custom/_home.scss
@@ -1,4 +1,12 @@
 .banner {
+    @include media-breakpoint-down(lg) {  
+        background-size: auto 100%;
+    }
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
     color: $white;
     min-height: 300px;
     background-image: url("./../../assets/images/banner.jpg");
@@ -7,9 +15,11 @@
     background-position: center top;
 
     h1 {
+        @include media-breakpoint-down(md) {  
+            background-size: auto 100%;
+        }
         @extend .display-2;
         margin: 0 !important;
-        padding-top: 40px;
     }
 
     h3 {


### PR DESCRIPTION
- Fix home header to not be cut off on mobile and vertically center text

Before (mobile):
![home-header-before](https://user-images.githubusercontent.com/26842896/214132614-ea46975a-43cf-4acf-9dc7-9df37d48ac42.png)

After (mobile):
![header-after-mobile](https://user-images.githubusercontent.com/26842896/214132623-d2438318-9697-44b5-a89b-5955169f8ab0.png)

Before (tablet):
![home-before-tablet](https://user-images.githubusercontent.com/26842896/214132636-2141cf93-b95e-4e58-a2cb-4db956433b17.png)

After (tablet):
![home-after-tablet](https://user-images.githubusercontent.com/26842896/214132645-0f470785-4ad8-4d9a-b274-da5602140079.png)

Before (desktop):
![home-desktop-before](https://user-images.githubusercontent.com/26842896/214132659-7af3f779-872f-4d72-8602-f20aa3dd91ba.png)

After (desktop):
![home-desktop-after](https://user-images.githubusercontent.com/26842896/214132668-3a969549-5bdc-4e33-a2e7-f68689cfa193.png)


## Type Of Change
- [ ] Update documentation
- [ ] Add feature
- [x] Fix 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Commit message is as per guidelines in the [contributor guide](https://github.com/WomenWhoCode/london/blob/main/CONTRIBUTING.md)