### PR TITLE
Add ad-hoc information in mentors page

### DIFF
--- a/_includes/search_mentor.html
+++ b/_includes/search_mentor.html
@@ -50,7 +50,7 @@
 
           <div class="search-type form-group mx-sm-1">
               <div class="form-check form-check-inline">
-                <input class="form-check-input" type="radio" name="mentorship-type" id="long-term-check" value="Long term relationship">
+                <input class="form-check-input" type="radio" name="mentorship-type" id="long-term-check" value="long-term">
                 <label class="form-check-label" for="long-term-check">Long Term relationship</label>
               </div>
           </div>

--- a/mentors.html
+++ b/mentors.html
@@ -8,9 +8,9 @@ title: Mentors
 {% include search_mentor.html %}
 
 <div class="mentors container">
-    <div class="description">
-        Below you can view all our mentors. The mentee's application for long-term relationship is until <b>13.03.2023</b>. Ad-hoc session starts in April.
-    </div>
+    <small>
+        Long-term mentorship registration is now open! Apply for up to 5 mentors till 13th of March. Ad-hoc session (one-time session) registration will be available in April. Check back then for more details.
+    </small>
     <div id="no-mentors-msg" class="alert alert-info d-none" role="alert">
         Sorry, no mentors matching your search criteria were found. Please, adjust your filters and try again.
     </div>
@@ -24,8 +24,13 @@ title: Mentors
                     <img src="{{mentor.image}}" class="card-img" alt="...">
                     <div class="card-link">
                         {% if mentor.type != 'ad-hoc' %}
-                            <a href="#" class="btn btn-outline-primary" data-tf-popup="XnMo1jOe" data-tf-iframe-props="title=Mentee Registration" 
+                            <a href="#" class="btn" data-tf-popup="XnMo1jOe" data-tf-iframe-props="title=Mentee Registration" 
                             data-tf-medium="snippet" data-tf-hidden="mentor={{mentor.name}}">Apply for this mentor</a>
+                        {% else %}
+                        <p class="card-text" data-toggle="tooltip" data-placement="bottom" data-html="true" title="One-time session registration will be available in late April.">
+                            Ad-hoc Mentor
+                            <span>{% include icons/question-fill.svg %}</span>
+                        </p>
                         {% endif %}
                     </div>
                 </div>

--- a/mentors.html
+++ b/mentors.html
@@ -128,7 +128,7 @@ title: Mentors
             <input type="hidden" name="mentor-data" 
                 value="{{mentor.name | downcase}} 
                     {{mentor.bio | normalize_whitespace | downcase}} 
-                    {% if mentor.type == 'both' %}long term relationship and ad-hoc {% else %}{{mentor.type | downcase}}{% endif %}
+                    {% if mentor.type == 'both' %}long-term and ad-hoc {% else %}{{mentor.type | downcase}}{% endif %}
                     {{mentor.skills.languages | downcase}} 
                     {{mentor.skills.extra | normalize_whitespace | downcase}} 
                     {{mentor.skills.focus | array_to_sentence_string | downcase}} 


### PR DESCRIPTION
* Fix long-term filter that was not working when mentor was only long-term type
* Add an extra label and tooltip for ad-hoc mentors to give more information why it is not possible to apply for the mentor. 
![image](https://user-images.githubusercontent.com/3664747/222926313-a332c450-3dcf-45e2-9074-408a833974e7.png)

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/3664747/222926334-1189f744-6978-4504-9f94-31482bd6cae3.png">