### PR TITLE
Enable Ad-Hoc sessions registration

### DIFF
--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -147,8 +147,8 @@
     - linkedin: www.linkedin.com/in/aishwarya-nair-data-scientist
 
 - name: Mr Andrew King
-  hours: 4
-  type: both
+  hours: 0
+  type: long-term
   index: 5
   position: SRE, Dojo
   bio: I have been mentoring for about 10 years now at all different levels.  I have good people skills and take active role in company development outside of engineering.  Currently an SRE, but 15 years as a back-end developer, various dev-ops roles has given me a wide range of technical experience.  30+ years in lots of firms have helped upskill my non-engineering skills.
@@ -504,7 +504,7 @@
     - linkedin: https://www.linkedin.com/in/preejababu/
 
 - name: Seyoung Joo
-  hours: 3
+  hours: 0
   type: long-term
   index: 21
   position: Frontend engineer, Fanduel
@@ -705,7 +705,7 @@
     - linkedin: https://www.linkedin.com/in/tatiana-merkulova-6458a650/
     
 - name: Anushka Yadav
-  hours: 5
+  hours: 0
   type: long-term
   index: 28
   position: Machine Learning Associate, PWC
@@ -793,7 +793,7 @@
     - twitter: https://twitter.com/monalsanghvi
 
 - name: Yana Lunts
-  hours: 5
+  hours: 0
   type: long-term
   index: 33
   position: SDET (Software developer in test), Apple
@@ -819,7 +819,7 @@
     - linkedin: https://www.linkedin.com/in/yana-lunts-a93a7818b/
 
 - name: Bomee Ryu
-  hours: 3
+  hours: 0
   type: long-term
   index: 34
   position: Android Developer, Sky UK
@@ -869,7 +869,7 @@
     - linkedin: https://www.linkedin.com/in/bisijoshfalade
 
 - name: Madhura Chaganty
-  hours: 3
+  hours: 0
   type: long-term
   index: 36
   position: Team Lead, Paythru Ltd.
@@ -1021,7 +1021,7 @@
     - github: https://github.com/marichka-offen
 
 - name: Dakshika Chauhan
-  hours: 2
+  hours: 0
   position: Senior Business Analyst, Amazon
   type: long-term
   index: 42

--- a/_sass/custom/_mentors.scss
+++ b/_sass/custom/_mentors.scss
@@ -13,6 +13,14 @@
         align-content: center;
         border-right: 1px solid rgba(0,0,0,0.125);
         border-radius: 0.25rem;
+
+        a {
+            margin-left: 15px !important;
+        }
+
+        .card-text {
+            padding-left: 30px !important;
+        }
     }
 
     .link {

--- a/_sass/custom/_mentors.scss
+++ b/_sass/custom/_mentors.scss
@@ -19,7 +19,7 @@
         }
 
         .card-text {
-            padding-left: 30px !important;
+            text-align: center;
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ title: Home
                 </ul> 
 
                 <p class="mt-4 d-flex justify-content-center">
-                    <a href="mentors.html" class='btn btn-primary'>Check our mentors</a>
+                    <a href="mentors.html" class='btn btn-primary'>Join as a Mentee</a>
                 </p>
             </div>
         </div>

--- a/mentors.html
+++ b/mentors.html
@@ -26,7 +26,7 @@ title: Mentors
                             <a href="#" class="btn" data-tf-popup="lADb5J9z" data-tf-iframe-props="title=Mentee Registration" 
                             data-tf-medium="snippet" data-tf-hidden="mentor={{mentor.name}}">Apply for this mentor</a>
                     {% else %}
-                    <p class="card-text" data-toggle="tooltip" data-placement="bottom" data-html="true" title="Only available for long mentorship">
+                    <p class="card-text" data-toggle="tooltip" data-placement="bottom" data-html="true" title="Only available for long-term mentorship">
                         Long Term <span>{% include icons/question-fill.svg %}</span>
                     </p>
                     {% endif %}

--- a/mentors.html
+++ b/mentors.html
@@ -15,13 +15,21 @@ title: Mentors
         Sorry, no mentors matching your search criteria were found. Please, adjust your filters and try again.
     </div>
     
-    {% assign mentors = site.data.mentors | sort: "type" | reverse %}
+    {% assign mentors = site.data.mentors | sort: "hours" | reverse %}
     {% for mentor in mentors %}
     
         <div class="card" id="mentor-card-{{mentor.index}}">
             <div class="row">
                 <div class="col-md-3">
                     <img src="{{mentor.image}}" class="card-img" alt="...">
+                    {% if mentor.type != 'long-term' %}
+                            <a href="#" class="btn" data-tf-popup="lADb5J9z" data-tf-iframe-props="title=Mentee Registration" 
+                            data-tf-medium="snippet" data-tf-hidden="mentor={{mentor.name}}">Apply for this mentor</a>
+                    {% else %}
+                    <p class="card-text" data-toggle="tooltip" data-placement="bottom" data-html="true" title="Only available for long mentorship">
+                        Long Term <span>{% include icons/question-fill.svg %}</span>
+                    </p>
+                    {% endif %}
                 </div>
 
                 <div class="col-md-9">


### PR DESCRIPTION
* Enable Ad-Hoc registration
* Sort mentors by hours
* Change hours for long-term mentors to zero, and give more visibility to available mentors
* Add text info to Long-term mentors just to explain the mentor is not available for ad-hoc session
* Change link in Home to mentee's

- Home Page
![image](https://user-images.githubusercontent.com/3664747/235295058-b9ba4c70-b82a-45c2-9bf3-b7ab3591b835.png)

- Mentor's Page
![image](https://user-images.githubusercontent.com/3664747/235294808-8e600c42-5d4e-4287-b598-f16de27edc03.png)
![image](https://user-images.githubusercontent.com/3664747/235294901-250b0e54-0404-41ec-8bf9-878ea387038a.png)
