### PR TITLE
Adjust ad-hoc timeline

### DIFF
--- a/ad-hoc-timeline.html
+++ b/ad-hoc-timeline.html
@@ -40,7 +40,7 @@ title: Ad-hoc Format Timeline
                     </li>
                     <li>
                         <h4>Program evaluation</h4>
-                        <div class="description">The mentor and mentee are responsible to inform the mentorship team the session happen and later by providing feedback. At the end of each month, the Mentorship Programme Team will collect feedback from mentors and evaluate feedback from mentees to identify areas for improvement and make any necessary adjustments. </div>
+                        <div class="description">Both mentor and mentee are responsible for informing the Mentorship Programme Team about the session taking place and providing feedback afterwards. At the end of each month, the Mentorship Programme Team will collect feedback from mentors and evaluate feedback from mentees to identify areas for improvement and make any necessary adjustments. </div>
                     </li>
                 </ul>
             </div>

--- a/ad-hoc-timeline.html
+++ b/ad-hoc-timeline.html
@@ -12,11 +12,11 @@ title: Ad-hoc Format Timeline
                     <li>
             
                         <h4>Application period</h4>
-                        <div class="description">Every month (from May to November), interested mentees will have the opportunity to apply to the one-time mentorship session program. The application process will be open for a specific period of time (a few weeks), and the applicants will need to provide information about their background, interests, and goals for the mentorship.</div>
+                        <div class="description">Every month (from May to November), interested mentees will have the opportunity to apply to the one-time mentorship session program. The application process will be open <b>the first week of the month</b> and the applicants will need to provide information about their background, interests, and goals for the mentorship.</div>
                     </li>
                     <li>
                         <h4>Mentee selection</h4>
-                        <div class="description">Once the application period has ended, the Mentorship Programme Team will review the applications and select the mentees who will participate in the program for the next month.</div>
+                        <div class="description">Once the application period has ended, the Mentorship Programme Team will review the applications and select the mentees who will participate in the program for the month.</div>
                     </li>
                     <li>
                         <h4>Mentor notification</h4>
@@ -24,7 +24,7 @@ title: Ad-hoc Format Timeline
                     </li>
                     <li>
                         <h4>Scheduling sessions</h4>
-                        <div class="description">Mentors will send a Calendly link and list of mentees to the Mentorship Programme Team, allowing these mentees to schedule sessions with the mentor directly.</div>
+                        <div class="description">Mentors will send a Calendly link or his availability to the mentee directly to be scheduled the session. Mentorship team will inform the mentees by email or slack when the mentor is not available.</div>
                     </li>
                     <li>
                         <h4>Session preparation</h4>
@@ -40,7 +40,7 @@ title: Ad-hoc Format Timeline
                     </li>
                     <li>
                         <h4>Program evaluation</h4>
-                        <div class="description">At the end of each month, the Mentorship Programme Team will collect feedback from mentors and evaluate feedback from mentees to identify areas for improvement and make any necessary adjustments.</div>
+                        <div class="description">The mentor and mentee are responsible to inform the mentorship team the session happen and later by providing feedback. At the end of each month, the Mentorship Programme Team will collect feedback from mentors and evaluate feedback from mentees to identify areas for improvement and make any necessary adjustments. </div>
                     </li>
                 </ul>
             </div>

--- a/ad-hoc-timeline.html
+++ b/ad-hoc-timeline.html
@@ -24,7 +24,7 @@ title: Ad-hoc Format Timeline
                     </li>
                     <li>
                         <h4>Scheduling sessions</h4>
-                        <div class="description">Mentors will send a Calendly link or his availability to the mentee directly to be scheduled the session. Mentorship team will inform the mentees by email or slack when the mentor is not available.</div>
+                        <div class="description">The mentors will directly provide the mentees with a Calendly link or their availability to schedule the session. Mentorship team will inform the mentees by email or slack when the mentor is not available.</div>
                     </li>
                     <li>
                         <h4>Session preparation</h4>


### PR DESCRIPTION
Applied the timeline changes: 
* First week of each month will be available the registration
* Mentor should contact the mentee and schedule
* Mentorship team will contact mentee when mentor is not available
* Mentor and mentee need to provide feedback


![image](https://user-images.githubusercontent.com/3664747/235295915-c708edef-13de-4cc4-a07b-b5db4b63dcaa.png)

![image](https://user-images.githubusercontent.com/3664747/235295958-ce5931b9-0bd1-4791-9d68-826afc2dfc7f.png)

![image](https://user-images.githubusercontent.com/3664747/235295969-5faf5e4b-4341-4f96-8082-2f8265c57763.png)
