### PR TITLE
fix: replace contact email in code of conduct with the new one

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -10,14 +10,14 @@ title: Code of Conduct
             <ol>
                 <li><em>WWCode is an inclusive community</em>, dedicated to providing an empowering experience for everyone who participates in or supports our community, regardless of gender, gender identity and expression, sexual orientation, ability, physical appearance, body size, race, ethnicity, age, religion, socioeconomic status, caste, creed, political affiliation, or preferred programming language(s).</li>
                 <li>Cancel or reschedule appointments with a minimum of 24 hours prior notice by providing a reason using preferable channel (email, slack, or anything else you both chose as the channel of communication) to the mentor.</li>
-                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:londonmentorship@womenwhocode.com">email</a>. The Mentorship Programme Team will evaluate case by case, and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles.</li>
+                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:londonmentorship@womenwhocode.com">londonmentorship@womenwhocode.com</a>. The Mentorship Programme Team will evaluate case by case, and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles.</li>
                 <li>No-replies by email or slack to the Mentorship Programme Team and/or mentor in a week are unacceptable during the program. Participants who applied but failed to reply without any reason provided will be banned from the current cycle.</li>
                 
                 <span id="mentee-conduct" class="d-none">
                     <li>Create a <a href="https://bit.ly/wwcodelondonslack">Slack Account</a>, join the #mentorship channel and check slack messages in the program to remain updated with all communication.</li>
                     <li>Come to your sessions well-prepared and with realistic expectations.</li>
                     <li>Whenever you see something is not going in the direction you want with the mentorship programme, provide feedback by email/slack or during your session with your mentor, so your mentor can adjust the sessions as necessary.</li>
-                    <li>If you have any concerns, don't hesitate to contact the Mentorship Programme Team (by slack or <a href="mailto:londonmentorship@womenwhocode.com">email</a>).</li>
+                    <li>If you have any concerns, don't hesitate to contact the Mentorship Programme Team (by slack or <a href="mailto:londonmentorship@womenwhocode.com">londonmentorship@womenwhocode.com</a>).</li>
                     <li>Attending the Mentees Catch up sessions is crucial for the programme's improvement:
                         <ul>
                             <li>It is <b>mandatory</b> to provide feedback using google forms shared with you before the session.</li>
@@ -40,7 +40,7 @@ title: Code of Conduct
             <ol>
                 <li><em>WWCode is an inclusive community</em>, dedicated to providing an empowering experience for everyone who participates in or supports our community, regardless of gender, gender identity and expression, sexual orientation, ability, physical appearance, body size, race, ethnicity, age, religion, socioeconomic status, caste, creed, political affiliation, or preferred programming language(s).</li>
                 <li>Cancel or reschedule appointments with a minimum of 24 hours prior notice by providing a reason by preferable channel (email, slack or anything else you both choose as the channel of communication) to the mentee.</li>
-                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:londonmentorship@womenwhocode.com">email</a>. The Mentorship Programme Team will evaluate case by case and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles. </li>
+                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:londonmentorship@womenwhocode.com">londonmentorship@womenwhocode.com</a>. The Mentorship Programme Team will evaluate case by case and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles. </li>
                 <span id="mentor-conduct" class="d-none">
                     <li>No-replies by email or slack to the Mentorship Programme Team and/or Mentee in a week are unacceptable during the program. Participants who applied but failed to reply without any reason provided will be banned from the current cycle.</li>
                     <li>Create a <a href="https://bit.ly/wwcodelondonslack">Slack Account</a>, join #mentorship channel and check slack messages in the program to remain updated with all communication.</li>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -10,14 +10,14 @@ title: Code of Conduct
             <ol>
                 <li><em>WWCode is an inclusive community</em>, dedicated to providing an empowering experience for everyone who participates in or supports our community, regardless of gender, gender identity and expression, sexual orientation, ability, physical appearance, body size, race, ethnicity, age, religion, socioeconomic status, caste, creed, political affiliation, or preferred programming language(s).</li>
                 <li>Cancel or reschedule appointments with a minimum of 24 hours prior notice by providing a reason using preferable channel (email, slack, or anything else you both chose as the channel of communication) to the mentor.</li>
-                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:london@womenwhocode.com">email</a>. The Mentorship Programme Team will evaluate case by case, and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles.</li>
+                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:londonmentorship@womenwhocode.com">email</a>. The Mentorship Programme Team will evaluate case by case, and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles.</li>
                 <li>No-replies by email or slack to the Mentorship Programme Team and/or mentor in a week are unacceptable during the program. Participants who applied but failed to reply without any reason provided will be banned from the current cycle.</li>
                 
                 <span id="mentee-conduct" class="d-none">
                     <li>Create a <a href="https://bit.ly/wwcodelondonslack">Slack Account</a>, join the #mentorship channel and check slack messages in the program to remain updated with all communication.</li>
                     <li>Come to your sessions well-prepared and with realistic expectations.</li>
                     <li>Whenever you see something is not going in the direction you want with the mentorship programme, provide feedback by email/slack or during your session with your mentor, so your mentor can adjust the sessions as necessary.</li>
-                    <li>If you have any concerns, don't hesitate to contact the Mentorship Programme Team (by slack or <a href="mailto:london@womenwhocode.com">email</a>).</li>
+                    <li>If you have any concerns, don't hesitate to contact the Mentorship Programme Team (by slack or <a href="mailto:londonmentorship@womenwhocode.com">email</a>).</li>
                     <li>Attending the Mentees Catch up sessions is crucial for the programme's improvement:
                         <ul>
                             <li>It is <b>mandatory</b> to provide feedback using google forms shared with you before the session.</li>
@@ -40,7 +40,7 @@ title: Code of Conduct
             <ol>
                 <li><em>WWCode is an inclusive community</em>, dedicated to providing an empowering experience for everyone who participates in or supports our community, regardless of gender, gender identity and expression, sexual orientation, ability, physical appearance, body size, race, ethnicity, age, religion, socioeconomic status, caste, creed, political affiliation, or preferred programming language(s).</li>
                 <li>Cancel or reschedule appointments with a minimum of 24 hours prior notice by providing a reason by preferable channel (email, slack or anything else you both choose as the channel of communication) to the mentee.</li>
-                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:london@womenwhocode.com">email</a>. The Mentorship Programme Team will evaluate case by case and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles. </li>
+                <li>No-shows are unacceptable for mentors and mentees. No-shows should be informed to the Mentorship Programme Team by <a href="mailto:londonmentorship@womenwhocode.com">email</a>. The Mentorship Programme Team will evaluate case by case and this is one of the possible actions that could result in exclusion from the current and future mentorship program cycles. </li>
                 <span id="mentor-conduct" class="d-none">
                     <li>No-replies by email or slack to the Mentorship Programme Team and/or Mentee in a week are unacceptable during the program. Participants who applied but failed to reply without any reason provided will be banned from the current cycle.</li>
                     <li>Create a <a href="https://bit.ly/wwcodelondonslack">Slack Account</a>, join #mentorship channel and check slack messages in the program to remain updated with all communication.</li>
@@ -48,7 +48,7 @@ title: Code of Conduct
                     <li>Update notion attendance page (template provided by the organization).</li>
                     <li>Provide information, guidance, constructive comments, and reflective listening to the mentee.</li>
                     <li>Provide a confidential and personalised source of career advice, support, and guidance to the mentee.</li>
-                    <li>Whenever you see something is not going in the direction you want with the mentorship programme, provide feedback by <a href="mailto:london@womenwhocode.com">email</a>/slack to the Mentorship Programme Team.</li>
+                    <li>Whenever you see something is not going in the direction you want with the mentorship programme, provide feedback by <a href="mailto:londonmentorship@womenwhocode.com">email</a>/slack to the Mentorship Programme Team.</li>
                     <li>Attending the Mentor's Catch Up sessions is crucial for the programme's improvement:
                         <ul>
                             <li>It is <b>mandatory</b> to provide feedback using google forms shared with you before the session.</li>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the email to londonmentorship@womenwhocode.com on code of conduct page 

Fix: #139 

## Change Type
- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other


## Related Issue
NA

## Motivation and Context
NA



## Screenshots
<img width="1012" alt="Screenshot 2023-10-18 at 2 46 59 PM" src="https://github.com/WomenWhoCode/london/assets/61655/bcff88ee-69c5-4c23-9da0-6e7670772fa1">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->