### PR TITLE
fix: use correct video link for second event

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -16,7 +16,7 @@
   index: 1
   description: In this session, WWCode London team provided attendees with a comprehensive overview of the mentorship programme, outlining its origins, highlighting the anticipated benefits, and guiding individuals on the registration process as mentors or mentees. The event culminated with an engaging panel discussion, where seasoned mentors shared their insights and addressed a multitude of questions from the audience.
   links:
-    - youtube: https://www.youtube.com/watch?v=AuDyfjDr9rA
+    - youtube: https://www.youtube.com/watch?v=mznVrMbcFxk
     - meetup: https://www.meetup.com/women-who-code-london/events/286468360
   enabled: true
 


### PR DESCRIPTION
The first 2 events on the "Resources" page were redirecting to the same video: https://www.youtube.com/watch?v=AuDyfjDr9rA

This PR fixes this by setting the correct link on the second video, "How to get the most out of Mentorship Programme?", to https://www.youtube.com/watch?v=mznVrMbcFxk

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
It fixes #157 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots
<!--  If you are chaging html, css or new resources it is mandatory to add screeshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->
Before:

https://github.com/WomenWhoCode/london/assets/99920845/98b2f6f4-e465-4c48-8de5-26f62388fcf1

After:

https://github.com/WomenWhoCode/london/assets/99920845/e20811d7-2a87-482e-abc6-74d1b607e9e4



## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->