### PR TITLE
feat: show mentor hours/month

### DIFF
--- a/mentors.html
+++ b/mentors.html
@@ -110,6 +110,9 @@ title: Mentors
                                 {% endif %}
                                 <span>{% include icons/question-fill.svg %}</span>
                             </p>
+                            {% if mentor.hours > 0 %}
+                                <p class="card-text justify-text"><label>Hours available per month</label>: {{mentor.hours}}</p>
+                            {% endif %}
                             <p class="card-text justify-text"><label>Ideal Mentee</label>: {{mentor.skills.mentee}}</p>
                             <p class="card-text">
                                 <label>Areas to support the mentee</label>:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the available hours per month for mentors (if applicable) to the 'Mentees' tab

## Change Type
- [ ] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other


## Related Issue
fixes #150 

## Motivation and Context
N/A

## Screenshots
<img width="1419" alt="Screenshot 2023-10-22 at 9 43 31 pm" src="https://github.com/WomenWhoCode/london/assets/38109438/d5d26f91-c1ce-432c-af27-0e15e4d396f7">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->