### PR TITLE
Updated styling for removing inactive mentors from mentors' list

### DIFF
--- a/_sass/custom/_mentors.scss
+++ b/_sass/custom/_mentors.scss
@@ -194,7 +194,7 @@
       }
     }
 
-    .disabled-mentor {
+    .inactive-mentor {
         display: none
     }
 }

--- a/_sass/custom/_mentors.scss
+++ b/_sass/custom/_mentors.scss
@@ -193,6 +193,10 @@
         }
       }
     }
+
+    .disabled-mentor {
+        display: none
+    }
 }
 
 .search {

--- a/mentors.html
+++ b/mentors.html
@@ -18,7 +18,7 @@ title: Mentors
     {% assign mentors = site.data.mentors | sort: "hours" | reverse %}
     {% for mentor in mentors %}
         {% if mentor.disabled %}
-            <div class="disabled-mentor" id="mentor-card-{{mentor.index}}"></div>
+            <div class="inactive-mentor" id="mentor-card-{{mentor.index}}"></div>
         {% else %}
             <div class="card" id="mentor-card-{{mentor.index}}">
                 <div class="row">

--- a/mentors.html
+++ b/mentors.html
@@ -18,7 +18,7 @@ title: Mentors
     {% assign mentors = site.data.mentors | sort: "hours" | reverse %}
     {% for mentor in mentors %}
         {% if mentor.disabled %}
-            <div class="card d-none" id="mentor-card-{{mentor.index}}"></div>
+            <div class="disabled-mentor" id="mentor-card-{{mentor.index}}"></div>
         {% else %}
             <div class="card" id="mentor-card-{{mentor.index}}">
                 <div class="row">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update

## Description
<!--- Describe your changes in detail -->
Updated styling for inactive mentors to a custom style. This avoids re-adding them to the list as empty cards when the "Clear filter" button is clicked.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When 'Clear filter' button is clicked, the current logic removes the display class (.d-none) from all mentor cards and that included inactive mentors. This causes the cards for inactive mentors to show but is empty.

## Screenshots
<!--  If you are chaging html, css or new resources it is mandatory to add screeshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->
**Before**
<img width="1405" alt="Screenshot 2024-02-06 at 9 11 09 pm" src="https://github.com/WomenWhoCode/london/assets/38109438/a39a4a29-6f36-4594-90cd-2483800694b4">

**After**
The empty card lines no longer show

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->