### PR TITLE
Correct Indexing of Mentors' Data

### DIFF
--- a/_data/mentors.yml
+++ b/_data/mentors.yml
@@ -1853,6 +1853,32 @@
   network:
     - linkedin: https://www.linkedin.com/in/liliia-rafikova-635328104/
 
+- name: Lidiane Mayra Taquehara
+  disabled: false
+  hours: 5
+  position: Senior Software Engineer, Artsy
+  type: both
+  index: 60
+  location: London, UK
+  bio: I'm a senior software engineer who migrated to IT after 10 years working on a complete different area (I was a factory worker in the past). I found my passion in the tech field and I'd love to help other women who are also interested in it.
+  image: assets/images/mentors/70.jpg
+  languages: English, Portuguese
+  skills:
+    experience: 7-10 Years
+    years: 10
+    mentee: A mentee with a curious mind and passionate about learning new things.
+    areas:
+      - Backend Developer
+      - QA
+      - Fullstack Developer
+    languages: JavaScript, Python, Ruby
+    focus:
+      - Switch career to IT
+      - Grow from beginner to mid-level
+    extra: Software engineering, Automated tests, Backend development, Test Driven Development, Web scraping
+  network:
+    - linkedin: https://www.linkedin.com/in/lmayra/
+
 - name: Julia Babahina
   disabled: false
   hours: 4
@@ -2109,29 +2135,3 @@
     extra: CV review, Technical Interview, Different roles in tech
   network:
     - linkedin: https://www.linkedin.com/in/victoria-beardow-b1b63814a
-
-- name: Lidiane Mayra Taquehara
-  disabled: false
-  hours: 5
-  position: Senior Software Engineer, Artsy
-  type: both
-  index: 70
-  location: London, UK
-  bio: I'm a senior software engineer who migrated to IT after 10 years working on a complete different area (I was a factory worker in the past). I found my passion in the tech field and I'd love to help other women who are also interested in it.
-  image: assets/images/mentors/70.jpg
-  languages: English, Portuguese
-  skills:
-    experience: 7-10 Years
-    years: 10
-    mentee: A mentee with a curious mind and passionate about learning new things.
-    areas:
-      - Backend Developer
-      - QA
-      - Fullstack Developer
-    languages: JavaScript, Python, Ruby
-    focus:
-      - Switch career to IT
-      - Grow from beginner to mid-level
-    extra: Software engineering, Automated tests, Backend development, Test Driven Development, Web scraping
-  network:
-    - linkedin: https://www.linkedin.com/in/lmayra/


### PR DESCRIPTION
## Description
Correected indexing of newly added mentors (index number 60 was skipped, which brought back the search bug).

**Note:** For future updates of mentors' data, please ensure to index from the next number after the last-added mentor. Indexing has a main impact on the current mentors' search logic.

## Change Type
- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Mentors' search bug fix: #234 

## Screenshots
<!--  If you are chaging html, css or new resources it is mandatory to add screeshot. -->
<!--  Please add screenshot from *before* and *after* to simply the code review -->
**Before**
<img width="1276" alt="Screenshot 2024-02-23 at 8 38 58 pm" src="https://github.com/WomenWhoCode/london/assets/38109438/7a8f6827-fde6-4543-83c4-b979d6b29b5f">

**After**
<img width="1276" alt="Screenshot 2024-02-23 at 8 38 21 pm" src="https://github.com/WomenWhoCode/london/assets/38109438/6b03b66a-603d-43c3-8403-94778b550b70">

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I checked and followed the [contributor guide](CONTRIBUTING.md) 
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->